### PR TITLE
reset cloudexec to version 0.1.0

### DIFF
--- a/Formula/cloudexec.rb
+++ b/Formula/cloudexec.rb
@@ -5,11 +5,11 @@
 class Cloudexec < Formula
   desc ""
   homepage "https://github.com/crytic/cloudexec"
-  version "0.1.10"
+  version "0.1.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/crytic/cloudexec/releases/download/v0.1.10/cloudexec-0.1.10-darwin-arm64.tar.gz"
+      url "https://github.com/crytic/cloudexec/releases/download/v0.1.0/cloudexec-0.1.0-darwin-arm64.tar.gz"
       sha256 "3ec9bc5be84401a813f7eb6a0ae8c517b0320d1d1f01860065f69292148cda35"
 
       def install
@@ -17,7 +17,7 @@ class Cloudexec < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/crytic/cloudexec/releases/download/v0.1.10/cloudexec-0.1.10-darwin-amd64.tar.gz"
+      url "https://github.com/crytic/cloudexec/releases/download/v0.1.0/cloudexec-0.1.0-darwin-amd64.tar.gz"
       sha256 "5dba6ea1c7cc60ee9afef85bc532d87a9f03a79655f40104639445c4a2ef201d"
 
       def install
@@ -28,7 +28,7 @@ class Cloudexec < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/crytic/cloudexec/releases/download/v0.1.10/cloudexec-0.1.10-linux-arm64.tar.gz"
+      url "https://github.com/crytic/cloudexec/releases/download/v0.1.0/cloudexec-0.1.0-linux-arm64.tar.gz"
       sha256 "a78059a930f35255603938deab7f1fbec75fc25f0f602babb6d4800818443b1d"
 
       def install
@@ -36,7 +36,7 @@ class Cloudexec < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/crytic/cloudexec/releases/download/v0.1.10/cloudexec-0.1.10-linux-amd64.tar.gz"
+      url "https://github.com/crytic/cloudexec/releases/download/v0.1.0/cloudexec-0.1.0-linux-amd64.tar.gz"
       sha256 "c9cdc38e12fd83dbe9780da285eb23da3cc7dad1a9154f827bdb0d8a58efb19f"
 
       def install


### PR DESCRIPTION
Version change seems to have gotten out-of-sync during the repo change + open source release. This should fix it.